### PR TITLE
Fix us future days

### DIFF
--- a/rtlive/sources/data_us.py
+++ b/rtlive/sources/data_us.py
@@ -158,7 +158,7 @@ def process_covidtracking_data(df_raw: pd.DataFrame):
     forecasting_results = {
     }
     # calculate the sum over all states ... again
-    df_all = df_corrected.sum(level='date')
+    df_all = df_corrected.sum(level='date', min_count=40)
     df_all.insert(0, column='region', value='all')
     df_all = df_all.reset_index().set_index(['region', 'date'])
     df_merged = pd.concat([df_corrected.drop(["all"]), df_all]).sort_index()


### PR DESCRIPTION
A `sum` operation to calculate the `"all"` region did not adequately handle `NaN` values, causing `0`s in the `"new_tests"` and `"new_cases"` columns for future days. `0` is regarded as data by the model, pulling the `r_t` down.

This PR fixes the `sum` operation such that it returns `NaN` for rows that have less than 40 valid numbers.