### PR TITLE
exchange deprecated miniconda installation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install miniconda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         activate-environment: rtlive-test


### PR DESCRIPTION
Fix CI:

- `goanpeca/setup-miniconda@v1` uses deprecated command in Github Actions
- `change to conda-incubator/setup-miniconda@v2`