### PR TITLE
Upgrade to PyMC3 3.11 to fix an ArviZ incompatibility

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,7 +17,6 @@ jobs:
         activate-environment: rtlive-test
         python-version: ${{ matrix.python-version }}
         channels: conda-forge
-        channel-priority: strict
     - name: Install dependencies
       shell: bash -l {0}
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pandas
   - pip
   - pymc3 >=3.11
+  - python =3.7
   - python-graphviz
   - requests
   - watermark

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - mkl-service
   - pandas
   - pip
-  - pymc3
+  - pymc3 >=3.11
   - python-graphviz
   - requests
   - watermark

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ fbprophet
 matplotlib
 mkl-service
 pandas
-pymc3 >=3.9.2
+pymc3 >=3.11
 requests


### PR DESCRIPTION
https://github.com/arviz-devs/arviz/releases/tag/v0.11.2 removed a statistic and for some reason the GitHub Actions here install PyMC3 3.10: https://github.com/rtcovidlive/rtlive-global/runs/1951985971?check_suite_focus=true#step:4:260