### PR TITLE
Fix DE-OWID-Correction not being applied to predicted testcounts.

### DIFF
--- a/rtlive/sources/data_de.py
+++ b/rtlive/sources/data_de.py
@@ -282,7 +282,7 @@ def get_testcounts_DE(run_date, take_latest:bool=True) -> pandas.DataFrame:
 
      # Get the sparse data of total tests from OWID
     df_owid = get_owid_summarized_totals(run_date)
-    df_merged = df_merged.assign(owid_total_tests=df_owid)
+    df_merged = df_merged.merge(df_owid, 'outer', left_index=True, right_index=True)
     return df_merged
 
 

--- a/rtlive/sources/data_de.py
+++ b/rtlive/sources/data_de.py
@@ -283,6 +283,7 @@ def get_testcounts_DE(run_date, take_latest:bool=True) -> pandas.DataFrame:
      # Get the sparse data of total tests from OWID
     df_owid = get_owid_summarized_totals(run_date)
     df_merged = df_merged.merge(df_owid, 'outer', left_index=True, right_index=True)
+    df_merged = df_merged.reindex(pandas.MultiIndex.from_product((df_merged.index.levels[0], df_merged.index.levels[1])))
     return df_merged
 
 


### PR DESCRIPTION
`df_merged.assign(owid_total_tests=df_owid)` does not appear to extend the index, so any OWID data after the last known daily test count is lost.

Please test with real data, because I could only test it with a mock `tests_daily_BL.CSV`.